### PR TITLE
Fix handling of array with nested schemas

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ var getSchema = function(object) {
       var refRegExp = /^#\/definitions\/(\w*)$/;
       var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'];
       var propType = refString.match(refRegExp)[1];
-      props[key] = getSchema(definitions[propType]['properties'] ? definitions[propType]['properties'] : definitions[propType]);
+      props[key] = [getSchema(definitions[propType]['properties'] ? definitions[propType]['properties'] : definitions[propType])];
     }
     else if (property.type) {
       var type = propertyMap(property);

--- a/test/index.js
+++ b/test/index.js
@@ -31,9 +31,10 @@ describe('swagger-mongoose tests', function () {
       sold: true,
       friends: ['Barney', 'Fido'],
       favoriteNumbers: [1, 3, 7, 9],
-      address: {
-        addressLine1: '1 Main St.'
-      },
+      address: [
+        {addressLine1: '1 Main St.'},
+        {addressLine1: '2 Main St.'}
+        ],
       notAKey: 'test'
     });
     myPet.save(function (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,8 @@ describe('swagger-mongoose tests', function () {
         assert(data.sold === true, 'Sold mismatch');
         assert(data.friends.length === 2, 'Friends mismatch');
         assert(data.favoriteNumbers.length === 4, 'Favorite numbers mismatch');
-        assert(data.address.addressLine1 === '1 Main St.', 'Nested address mismatch');
+        assert(data.address[0].addressLine1 === '1 Main St.', 'Nested address mismatch');
+        assert(data.address[1].addressLine1 === '2 Main St.', 'Nested address mismatch');
         assert(!data.notAKey, 'Strict schema mismatch');
         done();
       });


### PR DESCRIPTION
Added [ ] around nested getSchema() call inside getSchema() to create mongoose schema that will support array with nested schema.
